### PR TITLE
Fix spelling typo

### DIFF
--- a/think-dock
+++ b/think-dock
@@ -45,7 +45,7 @@ set_brightness=true
 # The value to set the brightness to. Needs to be given as a percentage.
 brightness="60%"
 
-relative_positon="right"
+relative_position="right"
 
 # Now import the configuration file if there is one. That will replace any
 # options set above.
@@ -122,7 +122,7 @@ case "$setto" in
 
 		# Set the displays to the right setting.
 		xrandr --output "$internal" --auto
-		xrandr --output "$external" --auto "--${relative_positon}-of" \
+		xrandr --output "$external" --auto "--${relative_position}-of" \
 			"$internal" --primary
 		) &
 

--- a/think-dock.1.rst
+++ b/think-dock.1.rst
@@ -103,7 +103,7 @@ You can set the following options:
 ``brightness``
     Brightness to set to when docking. Set it to a percentage like ``60%``.
 
-``relative_positon``
+``relative_position``
     Where to set the external monitor. Set it to ``right`` or ``left`` or
     anything else that ``xrandr`` supports with a ``--*-of`` argument.
 


### PR DESCRIPTION
The sample config in the `think-dock` man page sets the variable `relative_position=left`, but this variable is named `relative_positon` in the actual `think-dock` script.  This commit fixes the spelling so that everything uses `relative_position`.
