### PR TITLE
Add support for other virtual keyboards

### DIFF
--- a/think-rotate
+++ b/think-rotate
@@ -18,7 +18,24 @@
 
 set -e
 
-internal=LVDS1
+###############################################################################
+#                                   options                                   #
+###############################################################################
+
+# The name of the internal display.
+internal="LVDS1"
+
+# The name of the virtual keyboard.
+virtual_kbd="kvkbd"
+
+# Now import the configuration file if there is one. That will replace any
+# options set above.
+configfile="$HOME/.config/think-rotate/rotate.sh"
+
+if [[ -f "$configfile" ]]
+then
+	source "$configfile"
+fi
 
 ###############################################################################
 #                               current status                                #
@@ -100,21 +117,21 @@ done
 #                              virtual keyboard                               #
 ###############################################################################
 
-# Start the virtual keyboard ``kvkbd``, if it is installed.
-if type kvkbd > /dev/null 2>&1
+# Start the virtual keyboard, if it is installed.
+if type "$virtual_kbd" > /dev/null 2>&1
 then
 	if [[ "$setto" = "normal" ]]
 	then
 		# So the user reverts back to normal. Kill the virtual keyboard (if it
 		# is running), since it does not make any sense to use that any more.
-		if pgrep kvkbd > /dev/null 2>&1
+		if pgrep "$virtual_kbd" > /dev/null 2>&1
 		then
-			killall kvkbd
+			killall "$virtual_kbd"
 		fi
 	else
 		# The user rotated the screen. Start the virtual keyboard since he
 		# might need it.
-		kvkbd > /dev/null 2>&1
+		"$virtual_kbd" > /dev/null 2>&1 &
 	fi
 fi
 

--- a/think-rotate.1.rst
+++ b/think-rotate.1.rst
@@ -30,6 +30,9 @@ It will also disable the trackpoint (the xinput id is automatically queried) so
 that the back of the screen does not move your mouse if there is any force on
 the side of the screen.
 
+Finally, it will start the virtual keyboard (``kvkbd`` by default) when the
+screen is rotated and kill it when the screen is rotated back to normal.
+
 If the screen is already rotated (say left) and you call ``think-rotate left``,
 the screen will be reverted to the normal orientation. That way, you can use
 this script as a toggle.
@@ -66,6 +69,21 @@ ENVIRONMENT
 ===========
 
 The script relies on ``xrandr`` to get the information, so this has to work.
+
+FILES
+=====
+
+You can create a config file in ``$HOME/.config/think-rotate/rotate.sh``, which
+is a simple Bash script that is going to be sourced from ``think-rotate``.
+
+A sample config would look like this::
+
+    virtual_kbd="cellwriter"
+
+You can set the following option:
+
+``virtual_kbd``
+    Command to start the virtual keyboard.
 
 EXAMPLE
 =======


### PR DESCRIPTION
`think-rotate` was hard-coded to run `kvkbd`. Personally, I prefer `cellwriter`, so this change allows the user to choose. (The default is still `kvkbd`.) This change also adds a config file just like `think-dock`, so that this parameter and future ones are easy for the user to customize.
