### PR TITLE
Fix Wacom mapping when rotating while docked

### DIFF
--- a/think-rotate
+++ b/think-rotate
@@ -111,6 +111,7 @@ echo "Rotating Wacom devices to $wacom_rotation."
 xsetwacom list devices | sed 's/id: .*//' | while read device
 do
 	xsetwacom set "$device" rotate "$wacom_rotation"
+	xsetwacom set "$device" MapToOutput "$internal"
 done
 
 ###############################################################################


### PR DESCRIPTION
Before, when rotating the screen while the computer was docked, the
mapping for the Wacom devices would rotate but not scale
properly. Remapping the devices to the internal display on every
rotation fixes the issue so that the Wacom devices always end up with
the correct mapping.
