### PR TITLE
Add support for systemd network interface names

### DIFF
--- a/bin/think-dock
+++ b/bin/think-dock
@@ -173,7 +173,7 @@ case "$setto" in
 		# Disable the wireless connection, if the user specified the option,
 		# the ``nmcli`` tool is available and the computer is actually
 		# connected to the ethernet.
-		if [[ "$disable_wifi" = "true" ]] && type nmcli &> /dev/null && [[ "$(cat "/sys/class/net/eth0/carrier")" = 1 ]]
+		if [[ "$disable_wifi" = "true" ]] && type nmcli &> /dev/null && grep 1 /sys/class/net/e*/carrier
 		then
 			# FIXME This does not work if invoked via the ``su -c '…' user``
 			# command from think-dock-hook.


### PR DESCRIPTION
From the documentation on http://freedesktop.org:

> Starting with v197 systemd/udev will automatically assign predictable, stable
> network interface names for all local Ethernet, WLAN, and WWAN interfaces.
> This is a departure from the traditional interface naming scheme (`eth0`,
> `eth1`, `wlan0`, ...), but should fix real problems.

The new scheme uses the following prefixes: `en*` for Ethernet, `wl*` for WLAN,
and `ww*` for WWAN. Therefore, simply using a prefix of `e*`, as is done in
this commit, should work fine for locating Ethernet interfaces in both the old
and new naming schemes.
