### PR TITLE
Add ACPI hook to automatically call think-rotate

### DIFF
--- a/bin/think-rotate-hook
+++ b/bin/think-rotate-hook
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Taken from think-dock-hook (Copyright © 2012-2013 Martin Ueding <dev@martin-ueding.de>)
+# Changes Copyright © 2013 Jim Turner <jturner314@gmail.com>
+
+TEXTDOMAIN=think-rotate
+
+set -e
+set -u
+
+# Find the user who is currently logged in on the primary screen.
+user="$(who -u | grep -F '(:0)' | head -n 1 | awk '{print $1}')"
+
+logger -t think-rotate -- "Using user $user."
+
+case "$4" in
+	00000001)
+		setto=right
+		;;
+	00000000)
+		setto=normal
+		;;
+esac
+
+su -c "DISPLAY=:0.0 kdialog=false /usr/bin/think-rotate $setto" --login "$user" &
+
+disown

--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ install:
 #
 	install -d "$(DESTDIR)/etc/acpi/events/"
 	install think-mutemic-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
+	install think-rotate-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
 #
 	install -d "$(DESTDIR)/usr/share/locale/de/LC_MESSAGES"
 	install locale/de/LC_MESSAGES/think-rotate.mo -t "$(DESTDIR)/usr/share/locale/de/LC_MESSAGES"

--- a/think-rotate-acpi-hook
+++ b/think-rotate-acpi-hook
@@ -1,0 +1,2 @@
+event=video/tabletmode TBLT 0000008A 0000000[01]
+action=/usr/bin/think-rotate-hook %e


### PR DESCRIPTION
This adds an ACPI hook to run `think-rotate` whenever the screen is laid down in tablet mode or raised back up in normal mode.
