### PR TITLE
Fix qdbus on Arch Linux systems without qtchooser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,13 +96,6 @@ showing dialog boxes        qdbus          qdbus            qt4
 virtual keyboard            kvkbd          kvkbd            kvkbd
 =========================== ============== ================ ==================
 
-Note: To use ``qdbus`` on Arch Linux, you should also install
-``qtchooser`` and configure it to use Qt 4 (see the ArchWiki_) or
-patch ``lib/kdialog.sh`` to call ``qdbus-qt4`` instead of ``qdbus``.
-A patch is available as part of the AUR package (coming soon).
-
-.. _ArchWiki: https://wiki.archlinux.org/index.php/Qt#Default_Qt_Toolkit
-
 Manual / How To Use
 ===================
 

--- a/lib/kdialog.sh
+++ b/lib/kdialog.sh
@@ -2,6 +2,13 @@
 # Copyright © 2013 Martin Ueding <dev@martin-ueding.de>
 # Licensed under The GNU Public License Version 2 (or later)
 
+if which qdbus-qt4 &> /dev/null
+then
+    qdbus=qdbus-qt4
+else
+    qdbus=qdbus
+fi
+
 kdialog-init() {
     if ! [[ "$kdialog" == "true" ]]
     then
@@ -24,8 +31,8 @@ kdialog-update() {
         return
     fi
 
-    qdbus $kdialog_handle setLabelText "$1" > /dev/null
-    qdbus $kdialog_handle Set "" value "$kdialog_number" > /dev/null
+    $qdbus $kdialog_handle setLabelText "$1" > /dev/null
+    $qdbus $kdialog_handle Set "" value "$kdialog_number" > /dev/null
     : $(( kdialog_number++ ))
 }
 
@@ -35,5 +42,5 @@ kdialog-exit() {
         return
     fi
 
-    qdbus $kdialog_handle close > /dev/null
+    $qdbus $kdialog_handle close > /dev/null
 }


### PR DESCRIPTION
Arch Linux installs symlinks in /usr/bin to the Qt binaries with names
in the form `name-qt4` for Qt 4, `name-qt5` for Qt 5, etc., so with just
Qt 4 installed, `qdbus-qt4` is on the system path but not `qdbus`.  The
`qtchooser` package is necessary to add `qdbus` to the system path.
This commit makes qdbus work properly even without `qtchooser` installed
because it calls `qdbus-qt4` when available and `qdbus` otherwise.
