### PR TITLE
Stop restarting acpid when installing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,14 @@ can build and install with::
     $ make
     # make install
 
-If you set a ``DESTDIR``, you will also need to run::
+To make the ACPI hooks take effect, you will need to restart ``acpid`` with the
+following on SysVinit/Upstart systems::
 
     # service acpid restart
+
+or on systemd systems::
+
+    # systemctl restart acpid
 
 Dependencies
 ============

--- a/makefile
+++ b/makefile
@@ -20,7 +20,6 @@ install:
 	install -d "$(DESTDIR)/etc/acpi/events/"
 	install think-mutemic-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
 	install think-rotate-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
-	if [[ -z "$(DESTDIR)" ]]; then service acpid restart; fi
 #
 	install -d "$(DESTDIR)/usr/share/locale/de/LC_MESSAGES"
 	for mofile in $(mo); \


### PR DESCRIPTION
The user will probably not expect a makefile to restart a system service when installing.  This commit removes this from the makefile and adds a note in the README for the user to restart `acpid` manually.

The other reason why it would be nice to remove this is that running `service acpid restart` does not work on Arch Linux.  The analogous command is `systemctl restart acpid`.  Some other systemd-based distributions, such as Fedora, have added a `service` compatibility command to make the old syntax work, but this is not part of systemd itself and as a result is not part of Arch Linux.

See this thread on the Arch Linux forums for more info: [How to restart services compatibly with SysVinit](https://bbs.archlinux.org/viewtopic.php?id=170989)
