### PR TITLE
Fix think-rotate-acpi-hook

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,8 +18,9 @@ install:
 	install -m 644 81-thinkpad-dock.rules -t "$(DESTDIR)/lib/udev/rules.d/"
 #
 	install -d "$(DESTDIR)/etc/acpi/events/"
-	install think-mutemic-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
-	install think-rotate-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 think-mutemic-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 think-rotate-acpi-hook-1 -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 think-rotate-acpi-hook-2 -t "$(DESTDIR)/etc/acpi/events/"
 #
 	install -d "$(DESTDIR)/usr/share/locale/de/LC_MESSAGES"
 	for mofile in $(mo); \

--- a/think-rotate-acpi-hook-1
+++ b/think-rotate-acpi-hook-1
@@ -2,8 +2,5 @@
 # Copyright © 2013 Martin Ueding <dev@martin-ueding.de>
 # Licensed under The GNU Public License Version 2 (or later)
 
-event=video/tabletmode TBLT 0000008A 0000000[01]
-action=/usr/bin/think-rotate-hook %e
-
 event=ibm/hotkey HKEY 00000080 0000500[9a]
 action=/usr/bin/think-rotate-hook %e

--- a/think-rotate-acpi-hook-2
+++ b/think-rotate-acpi-hook-2
@@ -1,0 +1,6 @@
+# Copyright © 2013 Jim Turner <jturner314@gmail.com>
+# Copyright © 2013 Martin Ueding <dev@martin-ueding.de>
+# Licensed under The GNU Public License Version 2 (or later)
+
+event=video/tabletmode TBLT 0000008A 0000000[01]
+action=/usr/bin/think-rotate-hook %e


### PR DESCRIPTION
For each hook file in /etc/acpi/events, `acpid` registers only the last
event listed. As a result, the handler for the `video/tabletmode...`
event was never called. Splitting `think-rotate-acpi-hook` into two
separate files fixes the issue.

Additionally, removed the execute permission from the ACPI event hooks
because it is not needed.
