### PR TITLE
Make udev rule apply only to docking station dock

### DIFF
--- a/81-thinkpad-dock.rules
+++ b/81-thinkpad-dock.rules
@@ -1,19 +1,10 @@
 # Copyright © 2012-2013 Martin Ueding <dev@martin-ueding.de>
+# Copyright © 2013 Jim Turner <jturner314@gmail.com>
 # Licensed under The GNU Public License Version 2 (or later)
 
-KERNEL=="dock.0", ATTR{docked}=="0", RUN+="/usr/bin/logger -t think-dock Event caught: off"
-KERNEL=="dock.0", ATTR{docked}=="1", RUN+="/usr/bin/logger -t think-dock Event caught: on"
-KERNEL=="dock.0", ATTR{docked}=="0", RUN+="/usr/bin/think-dock-hook off"
-KERNEL=="dock.0", ATTR{docked}=="1", RUN+="/usr/bin/think-dock-hook on"
-
-KERNEL=="dock.1", ATTR{docked}=="0", RUN+="/usr/bin/logger -t think-dock Event caught: off"
-KERNEL=="dock.1", ATTR{docked}=="1", RUN+="/usr/bin/logger -t think-dock Event caught: on"
-KERNEL=="dock.1", ATTR{docked}=="0", RUN+="/usr/bin/think-dock-hook off"
-KERNEL=="dock.1", ATTR{docked}=="1", RUN+="/usr/bin/think-dock-hook on"
-
-KERNEL=="dock.2", ATTR{docked}=="0", RUN+="/usr/bin/logger -t think-dock Event caught: off"
-KERNEL=="dock.2", ATTR{docked}=="1", RUN+="/usr/bin/logger -t think-dock Event caught: on"
-KERNEL=="dock.2", ATTR{docked}=="0", RUN+="/usr/bin/think-dock-hook off"
-KERNEL=="dock.2", ATTR{docked}=="1", RUN+="/usr/bin/think-dock-hook on"
+KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="0", RUN+="/usr/bin/logger -t think-dock Event caught: off"
+KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="1", RUN+="/usr/bin/logger -t think-dock Event caught: on"
+KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="0", RUN+="/usr/bin/think-dock-hook off"
+KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="1", RUN+="/usr/bin/think-dock-hook on"
 
 # vim: ft=udevrules


### PR DESCRIPTION
Fixes #27. This commit makes the udev rules apply only to docks with type
`dock_station`. (Other possibilities are `battery_bay` and `ata_bay`.)
