### PR TITLE
Add support for other X screen naming style

### DIFF
--- a/bin/think-dock-hook
+++ b/bin/think-dock-hook
@@ -8,7 +8,7 @@ set -e
 set -u
 
 # Find the user who is currently logged in on the primary screen.
-user="$(who -u | grep -F '(:0)' | head -n 1 | awk '{print $1}')"
+user="$(who -u | grep -E '\(:0(\.0)?\)' | head -n 1 | awk '{print $1}')"
 
 logger -t think-dock -- "Using user $user."
 

--- a/bin/think-rotate-hook
+++ b/bin/think-rotate-hook
@@ -9,7 +9,7 @@ set -e
 set -u
 
 # Find the user who is currently logged in on the primary screen.
-user="$(who -u | grep -F '(:0)' | head -n 1 | awk '{print $1}')"
+user="$(who -u | grep -E '\(:0(\.0)?\)' | head -n 1 | awk '{print $1}')"
 
 logger -t think-rotate-hook -i -- $"Using user $user."
 


### PR DESCRIPTION
X screen names can be of the form `(:0)` or `(:0.0)`; add support for the latter style. I recently switched to using XFCE without a display manager and noticed this issue.
