### PR TITLE
Fix config migration in some cases

### DIFF
--- a/tps/config.py
+++ b/tps/config.py
@@ -104,7 +104,7 @@ def interpret_shell_line(line, config):
         return
 
     known_options = {
-        'diable_wifi': ('network', 'disable_wifi'),
+        'disable_wifi': ('network', 'disable_wifi'),
         'internal': ('screen', 'internal'),
         'unmute': ('sound', 'unmute'),
         'dock_loudness': ('sound', 'dock_loudness'),


### PR DESCRIPTION
We should check that each old configuration file exists before attempting to read it. (For example, I had a `dock.sh` file but not a `rotate.sh` file.) Additionally, I fixed a typo.
