### PR TITLE
Replace calls to `which` with Python `os` funcs

### DIFF
--- a/tps/__init__.py
+++ b/tps/__init__.py
@@ -82,7 +82,7 @@ def has_program(command):
         return os.path.isfile(path) and os.access(path, os.X_OK)
 
     # Check if `command` is a path to an executable
-    if os.path.dirname(command):
+    if os.sep in command:
         if is_exe(os.path.expanduser(command)):
             logger.debug('Command “{}” found.'.format(command))
             return True


### PR DESCRIPTION
Note that `os.get_exec_path()` was added in Python v3.2. If we plan to support older versions of Python, the call to `os.get_exec_path()` will need to be replaced with getting the `PATH` environment variable and splitting it by `os.pathsep`.
