### PR TITLE
Fix tps.config.interpret_shell_line

### DIFF
--- a/tps/config.py
+++ b/tps/config.py
@@ -74,7 +74,6 @@ def migrate_shell_config():
         if os.path.isfile(old_file):
             with open(old_file) as handle:
                 for line in handle:
-                    line = line.strip()
                     try:
                         interpret_shell_line(line, config)
                     except ShellParseException as exception:


### PR DESCRIPTION
This fixes a couple of small bugs I found while writing unit tests for `tps.config.interpret_shell_line`. (See #53.)
