### PR TITLE
Fill in Arch Linux package names for dependencies

### DIFF
--- a/doc/guides/getting-started.rst
+++ b/doc/guides/getting-started.rst
@@ -135,6 +135,7 @@ required.
 ============== ================== ================== ===========================
 Needed Program Debian package     Arch Linux package For
 ============== ================== ================== ===========================
+gsettings      ??                 glib2              subpixel anti-alias order
 kvkbd          kvkbd              kvkbd              virtual keyboard
 nmcli          network-manager    networkmanager     changing wifi
 pactl          pulseaudio-utils   libpulse           volume control when docking


### PR DESCRIPTION
I filled in the corresponding Arch Linux package names. Is _setuptools_ really needed for running the scripts, not just building them?

Edit: I just noticed that a dependency needed to be added for gsettings. This is in e442ddb1d820b4b01409d6446178e503bf67fd15.
