### PR TITLE
Add dependency on Python termcolor package

### DIFF
--- a/doc/guides/getting-started.rst
+++ b/doc/guides/getting-started.rst
@@ -89,6 +89,7 @@ msgfmt         gettext            gettext
 python3        python3            python
 *setuptools*   python3-setuptools python-setuptools
 sphinx-build   python3-sphinx     python-sphinx
+*termcolor*    TODO               python-termcolor
 xgettext       gettext            gettext
 ============== ================== ==================
 
@@ -105,6 +106,7 @@ amixer         alsa-utils               alsa-utils
 linux                                                      >= 3.11.0-17 [1]_
 python3        python3                  python
 *setuptools*   python3-setuptools       python-setuptools
+*termcolor*    TODO                     python-termcolor
 *udev*         udev                     systemd            >= 196
 xsetwacom      xserver-xorg-input-wacom xf86-input-wacom
 xinput         xinput                   xorg-xinput


### PR DESCRIPTION
`termcolor` is necessary for most of the modules to run. It is also needed to build the documentation because otherwise autodoc complains that it can't import the modules.
