### PR TITLE
Add setup.py install to makefile install target

### DIFF
--- a/doc/guides/getting-started.rst
+++ b/doc/guides/getting-started.rst
@@ -44,7 +44,6 @@ Then, you can build and install with:
 
     $ make
     # make install
-    # ./setup.py install
 
 To make the ACPI hooks take effect, you will need to restart ``acpid`` with the
 following on SysVinit/Upstart systems:

--- a/makefile
+++ b/makefile
@@ -24,6 +24,8 @@ install:
 	if [[ -z "$(DESTDIR)" ]] && which service &> /dev/null; then service acpid restart; fi
 	if [[ -z "$(DESTDIR)" ]] && which systemctl &> /dev/null; then systemctl restart acpid; fi
 #
+	./setup.py install --root="$(or $(DESTDIR),/)"
+#
 	cd desktop && $(MAKE) install
 	cd doc && $(MAKE) install
 


### PR DESCRIPTION
Before, two calls were required to install `thinkpad-scripts`: one to `make` and one to `setup.py`. Now, only a single call to `make` is needed.
