### PR TITLE
Add support for nmcli v0.9.10

### DIFF
--- a/tps/network.py
+++ b/tps/network.py
@@ -110,9 +110,10 @@ def get_ethernet_con_name():
         command = ['nmcli', '--terse', '--fields', 'NAME,TYPE', 'con', 'list']
     lines = tps.check_output(command, logger).decode()
     for line in lines.split('\n'):
-        name, type = parse_terse_line(line)
-        if 'ethernet' in type.lower():
-            return name
+        if line.strip():
+            name, type = parse_terse_line(line)
+            if 'ethernet' in type.lower():
+                return name
     raise MissingEthernetException('No configured Ethernet connections.')
 
 def restart(connection):


### PR DESCRIPTION
This pull request partly fixes issue #74. The remaining issues are the following:
1. The call to `nmcli con down id <connection>` in the `restart()` function fails when the connection is inactive. `nmcli` says `Error: 'Wired connection 1' is not an active connection.`
2. It turns out that there is no distinguishable difference between the physical ethernet connection and virtual connections when they are inactive. (I had previously thought that the `DEVICE` field was different, but that's only true when they are active.)

To work around (1), it would be possible to check if the network connection is active before trying to take it down. However, simply running `nmcli con up id <connection>` (without previously running the `down` command) seems sufficient to restart the connection. Is this true for older versions of `nmcli`, as well? If so, we might as well remove the `nmcli con down id <connection>` command entirely.

To work around (2), the easiest solution would be to assume that the alphabetically first ethernet connection name is the physical one. (Prefer `Wired connection 1` over `Wired connection 2`.) Alternatively, it is possible to:
- get the MAC address of a connection from `nmcli con show id <connection>`
- get the MAC addresses of the devices with `nmcli device show`
- match the MAC address of the connection to a device to get the name of the device
- based on the device name, guess if it's a physical device. (Prefer `enp0s25` and `eth0` over `vboxnet0`.)

We already assume that physical ethernet device names start with the letter `e` in `has_ethernet()`, anyway, so this may be the better way to go. Which method do you prefer? Do you know of any better alternatives?
