### PR TITLE
Add support for multiple external screens

### DIFF
--- a/doc/man/thinkpad-dock.1.rst
+++ b/doc/man/thinkpad-dock.1.rst
@@ -1,4 +1,5 @@
 ..  Copyright © 2013-2014 Martin Ueding <dev@martin-ueding.de>
+    Copyright © 2015 Jim Turner <jturner314@gmail.com>
     Licensed under The GNU Public License Version 2 (or later)
 
 #############
@@ -128,6 +129,14 @@ Those are the possible options:
 ``screen.internal``
     The ``xrandr`` name for the internal monitor. *Default: LVDS1*.
 
+``screen.primary``
+    The ``xrandr`` name for the primary monitor when docked or an empty string
+    to guess a reasonable monitor. *Default: (empty string)*.
+
+``screen.secondary``
+    The ``xrandr`` name for the secondary monitor when docked or an empty
+    string to guess a reasonable monitor. *Default: (empty string)*.
+
 ``screen.set_brightness``
     Whether to change the brightness. *Default: true*.
 
@@ -135,9 +144,9 @@ Those are the possible options:
     Brightness to set to when docking. *Default: 60%*.
 
 ``screen.relative_position``
-    Where to set the external monitor. Set it to ``right-of`` or ``left-of`` or
-    anything else that ``xrandr`` supports with a ``--*`` argument. *Default:
-    right-of*.
+    Where to set the primary monitor relative to the secondary monitor when
+    docking. Set it to ``right-of`` or ``left-of`` or anything else that
+    ``xrandr`` supports with a ``--*`` argument. *Default: right-of*.
 
 ``sound.unmute``
     Whether to change the volume. *Default: true*.

--- a/tps/default.ini
+++ b/tps/default.ini
@@ -1,4 +1,5 @@
 # Copyright © 2014 Martin Ueding <dev@martin-ueding.de>
+# Copyright © 2015 Jim Turner <jturner314@gmail.com>
 # Licensed under The GNU Public License Version 2 (or later)
 
 [gui]
@@ -24,6 +25,8 @@ subpixels_with_external = false
 
 [screen]
 internal = LVDS1
+primary =
+secondary =
 set_brightness = true
 brightness = 60%
 relative_position = left-of

--- a/tps/rotate.py
+++ b/tps/rotate.py
@@ -48,7 +48,7 @@ def rotate_to(direction, config):
 
     if config['rotate'].getboolean('subpixels'):
         if config['rotate'].getboolean('subpixels_with_external') \
-           or tps.screen.get_external(config['screen']['internal']) is None:
+           or not tps.screen.get_externals(config['screen']['internal']):
             tps.screen.set_subpixel_order(direction)
 
     if config['unity'].getboolean('toggle_launcher'):

--- a/tps/screen.py
+++ b/tps/screen.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright © 2014 Martin Ueding <dev@martin-ueding.de>
+# Copyright © 2015 Jim Turner <jturner314@gmail.com>
 # Licensed under The GNU Public License Version 2 (or later)
 
 '''
@@ -34,25 +35,24 @@ def get_rotation(screen):
                 logger.info('Current rotation is “{}”.'.format(rotation))
                 return rotation
 
-def get_external(internal):
+def get_externals(internal):
     '''
-    Gets the external screen.
+    Gets the external screens.
 
     You have to specify the internal screen to exclude that from the listing.
-    This returns the first external screen. Since you could possibly have
-    multiple, this might be adjusted. The graphics card in the X220 (Intel HD
-    3000) can only use two screens, so this might be okay right here.
 
     ;param str internal: Name of the internal screen
-    :returns: External screen name
+    :returns: List of external screen names
     :rtype: str
     '''
+    externals = []
     lines = tps.check_output(['xrandr'], logger).decode().split('\n')
     for line in lines:
         if not line.startswith(internal):
             matcher = re.search(r'^(\S+) connected', line)
             if matcher:
-                return matcher.group(1)
+                externals.append(matcher.group(1))
+    return externals
 
 def rotate(screen, direction):
     '''

--- a/tps/testsuite/test_dock.py
+++ b/tps/testsuite/test_dock.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# Copyright © 2015 Jim Turner <jturner314@gmail.com>
+# Licensed under The GNU Public License Version 2 (or later)
+
+import unittest
+
+import tps.dock
+
+def set_externals(externals):
+    def get_externals(internal):
+        return externals
+    tps.dock.tps.screen.get_externals = get_externals
+
+class SelectDockingScreensTestCase(unittest.TestCase):
+
+    def test_select_docking_screens_internal_only(self):
+        set_externals([])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', ''),
+            ('LVDS1', None, []))
+
+    def test_select_docking_screens_single_external_infer_both(self):
+        set_externals(['VGA1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', ''),
+            ('VGA1', 'LVDS1', []))
+
+    def test_select_docking_screens_dual_external_infer_both(self):
+        set_externals(['VGA1', 'HDMI1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', ''),
+            ('VGA1', 'HDMI1', ['LVDS1']))
+
+    def test_select_docking_screens_single_external_infer_primary(self):
+        set_externals(['VGA1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', 'LVDS1'),
+            ('VGA1', 'LVDS1', []))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', 'VGA1'),
+            ('LVDS1', 'VGA1', []))
+
+    def test_select_docking_screens_dual_external_infer_primary(self):
+        set_externals(['VGA1', 'HDMI1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', 'LVDS1'),
+            ('VGA1', 'LVDS1', ['HDMI1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', 'VGA1'),
+            ('HDMI1', 'VGA1', ['LVDS1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', '', 'HDMI1'),
+            ('VGA1', 'HDMI1', ['LVDS1']))
+
+    def test_select_docking_screens_single_external_infer_secondary(self):
+        set_externals(['VGA1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'LVDS1', ''),
+            ('LVDS1', 'VGA1', []))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'VGA1', ''),
+            ('VGA1', 'LVDS1', []))
+
+    def test_select_docking_screens_dual_external_infer_secondary(self):
+        set_externals(['VGA1', 'HDMI1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'LVDS1', ''),
+            ('LVDS1', 'VGA1', ['HDMI1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'VGA1', ''),
+            ('VGA1', 'HDMI1', ['LVDS1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'HDMI1', ''),
+            ('HDMI1', 'VGA1', ['LVDS1']))
+
+    def test_select_docking_screens_single_external_infer_neither(self):
+        set_externals(['VGA1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'VGA1'),
+            ('LVDS1', 'VGA1', []))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'VGA1', 'LVDS1'),
+            ('VGA1', 'LVDS1', []))
+
+    def test_select_docking_screens_dual_external_infer_neither(self):
+        set_externals(['VGA1', 'HDMI1'])
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'VGA1'),
+            ('LVDS1', 'VGA1', ['HDMI1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'HDMI1'),
+            ('LVDS1', 'HDMI1', ['VGA1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'VGA1', 'LVDS1'),
+            ('VGA1', 'LVDS1', ['HDMI1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'VGA1', 'HDMI1'),
+            ('VGA1', 'HDMI1', ['LVDS1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'HDMI1', 'VGA1'),
+            ('HDMI1', 'VGA1', ['LVDS1']))
+        self.assertEqual(
+            tps.dock.select_docking_screens('LVDS1', 'HDMI1', 'LVDS1'),
+            ('HDMI1', 'LVDS1', ['VGA1']))
+
+    def test_select_docking_screens_internal_only_bad_config(self):
+        set_externals([])
+        with self.assertLogs(tps.dock.logger, level='WARNING') as cm:
+            self.assertEqual(
+                tps.dock.select_docking_screens('LVDS1', 'foo', 'bar'),
+                ('LVDS1', None, []))
+        self.assertEqual(
+            cm.output, ['WARNING:tps.dock:Configured screen "foo" does not '
+                        'exist or is not connected.',
+                        'WARNING:tps.dock:Configured screen "bar" does not '
+                        'exist or is not connected.'])
+
+    def test_select_docking_screens_single_external_bad_config(self):
+        set_externals(['VGA1'])
+        with self.assertLogs(tps.dock.logger, level='WARNING') as cm:
+            self.assertEqual(
+                tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'foo'),
+                ('LVDS1', 'VGA1', []))
+        self.assertEqual(
+            cm.output, ['WARNING:tps.dock:Configured screen "foo" does not '
+                        'exist or is not connected.'])
+
+    def test_select_docking_screens_dual_external_bad_config(self):
+        set_externals(['VGA1', 'HDMI1'])
+        with self.assertLogs(tps.dock.logger, level='WARNING') as cm:
+            self.assertEqual(
+                tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'foo'),
+                ('LVDS1', 'VGA1', ['HDMI1']))
+        self.assertEqual(
+            cm.output, ['WARNING:tps.dock:Configured screen "foo" does not '
+                        'exist or is not connected.'])


### PR DESCRIPTION
I recently acquired a second external monitor, so I added support for multiple external screens. (The code should work with arbitrarily many external screens.) I added two configuration options, `screen.primary` and `screen.secondary` to allow the user to specify the desired screens in ambiguous cases. The behavior of `thinkpad-dock` should be fully backwards compatible.

Please let me know if you'd like me to make any edits to this PR.