### PR TITLE
Use patch() to cleanly mock get_externals()

### DIFF
--- a/tps/testsuite/test_dock.py
+++ b/tps/testsuite/test_dock.py
@@ -5,36 +5,40 @@
 # Licensed under The GNU Public License Version 2 (or later)
 
 import unittest
+import unittest.mock
 
 import tps.dock
 
-def set_externals(externals):
-    def get_externals(internal):
-        return externals
-    tps.dock.tps.screen.get_externals = get_externals
-
 class SelectDockingScreensTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.get_externals_patcher = unittest.mock.patch(
+            'tps.screen.get_externals', autospec=True)
+        self.get_externals_mock = self.get_externals_patcher.start()
+
+    def tearDown(self):
+        self.get_externals_patcher.stop()
+
     def test_select_docking_screens_internal_only(self):
-        set_externals([])
+        self.get_externals_mock.return_value = []
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', '', ''),
             ('LVDS1', None, []))
 
     def test_select_docking_screens_single_external_infer_both(self):
-        set_externals(['VGA1'])
+        self.get_externals_mock.return_value = ['VGA1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', '', ''),
             ('VGA1', 'LVDS1', []))
 
     def test_select_docking_screens_dual_external_infer_both(self):
-        set_externals(['VGA1', 'HDMI1'])
+        self.get_externals_mock.return_value = ['VGA1', 'HDMI1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', '', ''),
             ('VGA1', 'HDMI1', ['LVDS1']))
 
     def test_select_docking_screens_single_external_infer_primary(self):
-        set_externals(['VGA1'])
+        self.get_externals_mock.return_value = ['VGA1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', '', 'LVDS1'),
             ('VGA1', 'LVDS1', []))
@@ -43,7 +47,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
             ('LVDS1', 'VGA1', []))
 
     def test_select_docking_screens_dual_external_infer_primary(self):
-        set_externals(['VGA1', 'HDMI1'])
+        self.get_externals_mock.return_value = ['VGA1', 'HDMI1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', '', 'LVDS1'),
             ('VGA1', 'LVDS1', ['HDMI1']))
@@ -55,7 +59,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
             ('VGA1', 'HDMI1', ['LVDS1']))
 
     def test_select_docking_screens_single_external_infer_secondary(self):
-        set_externals(['VGA1'])
+        self.get_externals_mock.return_value = ['VGA1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', 'LVDS1', ''),
             ('LVDS1', 'VGA1', []))
@@ -64,7 +68,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
             ('VGA1', 'LVDS1', []))
 
     def test_select_docking_screens_dual_external_infer_secondary(self):
-        set_externals(['VGA1', 'HDMI1'])
+        self.get_externals_mock.return_value = ['VGA1', 'HDMI1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', 'LVDS1', ''),
             ('LVDS1', 'VGA1', ['HDMI1']))
@@ -76,7 +80,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
             ('HDMI1', 'VGA1', ['LVDS1']))
 
     def test_select_docking_screens_single_external_infer_neither(self):
-        set_externals(['VGA1'])
+        self.get_externals_mock.return_value = ['VGA1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'VGA1'),
             ('LVDS1', 'VGA1', []))
@@ -85,7 +89,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
             ('VGA1', 'LVDS1', []))
 
     def test_select_docking_screens_dual_external_infer_neither(self):
-        set_externals(['VGA1', 'HDMI1'])
+        self.get_externals_mock.return_value = ['VGA1', 'HDMI1']
         self.assertEqual(
             tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'VGA1'),
             ('LVDS1', 'VGA1', ['HDMI1']))
@@ -106,7 +110,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
             ('HDMI1', 'LVDS1', ['VGA1']))
 
     def test_select_docking_screens_internal_only_bad_config(self):
-        set_externals([])
+        self.get_externals_mock.return_value = []
         with self.assertLogs(tps.dock.logger, level='WARNING') as cm:
             self.assertEqual(
                 tps.dock.select_docking_screens('LVDS1', 'foo', 'bar'),
@@ -118,7 +122,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
                         'exist or is not connected.'])
 
     def test_select_docking_screens_single_external_bad_config(self):
-        set_externals(['VGA1'])
+        self.get_externals_mock.return_value = ['VGA1']
         with self.assertLogs(tps.dock.logger, level='WARNING') as cm:
             self.assertEqual(
                 tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'foo'),
@@ -128,7 +132,7 @@ class SelectDockingScreensTestCase(unittest.TestCase):
                         'exist or is not connected.'])
 
     def test_select_docking_screens_dual_external_bad_config(self):
-        set_externals(['VGA1', 'HDMI1'])
+        self.get_externals_mock.return_value = ['VGA1', 'HDMI1']
         with self.assertLogs(tps.dock.logger, level='WARNING') as cm:
             self.assertEqual(
                 tps.dock.select_docking_screens('LVDS1', 'LVDS1', 'foo'),


### PR DESCRIPTION
Before, the `tps.dock.tps.screen.get_externals` variable was being modified directly, and this was not cleaned up afterward. Now, the `unittest.mock.patch()` function is used to setup a mock for `tps.screen.get_externals` before each test and restore the original value after each test.

The test results should be the same regardless, so we shouldn't need a new release just for this.

I liked the original way that I mocked the test, but it felt a little awkward to me. I did some looking and came across the `unittest.mock.patch()` function, which is really awesome. Using the `autospec` option, it will automatically create a mock object with the same name, call signature, etc. as the original object. This mock object has a `return_value` attribute that can be set directly. Calling `start()` and `stop()` on the patcher object automatically puts the patch in place and then removes it.

By the way, you can also use `unittest.mock.patch()` as a context manager (for use with a `with` block) or a function decorator. The `unittest.mock` module also provides a `create_autospec()` function separately from the `patch()` function. The `unittest.mock` module is pretty cool.