### PR TITLE
Remove mailing list from front page of docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,10 +27,6 @@ tracker.
     `GitHub page <https://github.com/martin-ueding/thinkpad-scripts/issues>`_
         - Issue tracker
         - git repository
-    `Mailing list <http://chaos.stw-bonn.de/cgi-bin/mailman/listinfo/thinkpad-scripts>`_
-        - General help
-        - Developer discussion
-        - Announcements
 
 Short introduction
 ==================


### PR DESCRIPTION
The mailing list no longer exists, so it needs to be removed from the documentation.