### PR TITLE
Add ScreenNotFoundException and update docking to use transformation matrix code

### DIFF
--- a/tps/dock.py
+++ b/tps/dock.py
@@ -146,6 +146,17 @@ def dock(on, config):
                 tps.network.restart(connection_to_restart)
             except tps.network.MissingEthernetException:
                 logger.warning('unable to find ethernet connection')
+
+        if primary == config['screen']['internal'] or \
+           secondary == config['screen']['internal']:
+            try:
+                tps.input.map_rotate_all_input_devices(
+                    config['screen']['internal'],
+                    tps.screen.get_rotation(config['screen']['internal']))
+            except tps.screen.ScreenNotFoundException as e:
+                logger.error('Unable to map input devices to "{}": {}'.format(
+                    config['screen']['internal'], e))
+
     else:
         for external in tps.screen.get_externals(config['screen']['internal']):
             tps.screen.disable(external)
@@ -158,7 +169,13 @@ def dock(on, config):
         if config['network'].getboolean('disable_wifi'):
             tps.network.set_wifi(True)
 
-    tps.input.map_all_wacom_devices_to_output(config['screen']['internal'])
+        try:
+            tps.input.map_rotate_all_input_devices(
+                config['screen']['internal'],
+                tps.screen.get_rotation(config['screen']['internal']))
+        except tps.screen.ScreenNotFoundException as e:
+            logger.error('Unable to map input devices to "{}": {}'.format(
+                config['screen']['internal'], e))
 
     tps.hooks.postdock(on, config)
 

--- a/tps/rotate.py
+++ b/tps/rotate.py
@@ -33,6 +33,10 @@ def main():
     except tps.UnknownDirectionException:
         logger.error('Direction cannot be understood.')
         sys.exit(1)
+    except tps.screen.ScreenNotFoundException as e:
+        logger.error('Unable to determine rotation of "{}": {}'.format(
+            config['screen']['internal'], e))
+        sys.exit(1)
 
     rotate_to(new_direction, config)
 

--- a/tps/screen.py
+++ b/tps/screen.py
@@ -18,6 +18,13 @@ import tps
 logger = logging.getLogger(__name__)
 
 
+class ScreenNotFoundException(Exception):
+    '''
+    ``xrandr`` device could not be found.
+    '''
+    pass
+
+
 def get_rotation(screen):
     '''
     Gets the current rotation of the given screen.
@@ -35,9 +42,12 @@ def get_rotation(screen):
                 rotation = tps.translate_direction(matcher.group(1))
                 logger.info('Current rotation is “{}”.'.format(rotation))
                 return rotation
-
-    # At this point, nothing was found in the xrandr output.
-    logger.error('Rotation of screen "%s" could not be determined. Do you have a screen like that in the output of "xrandr"? Maybe you have to adjust the option of screen.internal in the configuration.', screen)
+    else:
+        raise ScreenNotFoundException(
+            'Screen "{}" is not enabled. Do you have a screen like that in '
+            'the output of "xrandr", and is it enabled? Maybe you have to '
+            'adjust the option of screen.internal in the '
+            'configuration.'.format(screen))
 
 
 def get_externals(internal):
@@ -196,6 +206,9 @@ def get_resolution_and_shift(output):
             result['screen_height'] = int(m_screen.group('height'))
 
     if len(result) != 6:
-        logger.error('The screen and output dimensions could not be gathered from xrandr. Maybe the internal output is not attached (currently %s)? Please report a bug otherwise.', output)
+        raise ScreenNotFoundException(
+            'The screen and output dimensions could not be gathered from '
+            'xrandr. Maybe the "{}" output is not attached or enabled? Please '
+            'report a bug otherwise.'.format(output))
 
     return result


### PR DESCRIPTION
Personally, I think raising and catching an exception is cleaner than logging an error and returning incomplete output. That's really a personal preference, though, so it's up to you. The `thinkpad-dock` does need to be updated to use the new function with the transformation matrix calculations.