### PR TITLE
Check if gsettings schema exists before using it

### DIFF
--- a/tps/screen.py
+++ b/tps/screen.py
@@ -84,9 +84,15 @@ def set_subpixel_order(direction):
 
     elif tps.has_program('gsettings'):
         try:
-            tps.check_call(['gsettings', 'set',
-                            'org.gnome.settings-daemon.plugins.xsettings',
-                            'rgba-order', direction.subpixel], logger)
+            schemas = tps.check_output(
+                ['gsettings', 'list-schemas']).decode().split('\n')
+            schema = 'org.gnome.settings-daemon.plugins.xsettings'
+            if schema in schemas:
+                tps.check_call(['gsettings', 'set', schema, 'rgba-order',
+                                direction.subpixel], logger)
+            else:
+                logger.warning('gsettings is installed, but the "{}" schema '
+                               'is not available'.format(schema))
         except subprocess.CalledProcessError as e:
             logger.error(e)
     else:


### PR DESCRIPTION
Before, if `gsettings` was installed but the `org.gnome.settings-daemon.plugins.xsettings` schema was not present, there would be an error message. Now, the scripts check if the schema is present before trying to use it, so only a warning is necessary if the schema is not present.

@martin-ueding Did we ever figure out how to do subpixel rotation on KDE? If so, it would be better to check if the necessary KDE program exists and use it (like we do for XFCE) instead of adding this extra logic for `gsettings`.