### PR TITLE
Remove heading from docstring to appease Sphinx

### DIFF
--- a/tps/screen.py
+++ b/tps/screen.py
@@ -167,11 +167,9 @@ def get_resolution_and_shift(output):
     physical displays. ``xrandr`` gives the size of that (virtual) screen as
     well as the positions of each display in that.
 
-    Example
-    =======
-
-    I currently have the 12.5" 1366×768 ThinkPad X220 display on the right of a
-    23" 1920×1080 pixel display. ``xrandr`` tells me the following::
+    For example, I currently have the 12.5" 1366×768 ThinkPad X220 display on
+    the right of a 23" 1920×1080 pixel display. ``xrandr`` tells me the
+    following::
 
         Screen 0: … current 3286 x 1080 …
         LVDS1 … 1366x768+1920+0


### PR DESCRIPTION
Sphinx complains about this heading. In the output of `make` is the following error message:
```
/home/jim/projects/thinkpad-scripts/tps/screen.py:docstring of tps.screen.get_resolution_and_shift:9: SEVERE: Unexpected section title.

Example
=======
```
This really isn't severe as Sphinx claims (the heading is simply removed from the API output), but it's worth fixing.