### PR TITLE
Update device name regexes in docs to xinput format

### DIFF
--- a/doc/guides/hw-specific-config.rst
+++ b/doc/guides/hw-specific-config.rst
@@ -44,7 +44,7 @@ the necessary configuration parameters:
     touchscreen_device = Serial Wacom Tablet touch
 
     [touch]
-    regex = Serial Wacom Tablet.*id: (\d+).*
+    regex = Serial Wacom Tablet.*id=(\d+)
 
 Lenovo Thinkpad X220 & Lenovo Thinkpad X220 Tablet
 --------------------------------------------------

--- a/doc/man/thinkpad-rotate.1.rst
+++ b/doc/man/thinkpad-rotate.1.rst
@@ -124,8 +124,8 @@ You can set the following option:
 
 ``touch.regex``
     Regular expression to match Wacom devices against. If your devices do not
-    start with ``Wacom ISD``, change this appropriately. *Default:* ``Wacom
-    ISD.*id: (\d+).*``
+    start with ``Wacom ISD``, change this appropriately.
+    *Default:* ``Wacom ISD.*id=(\d+)``
 
 ``unity.toggle_launcher``
     The Unity Launcher on the left side is only shown if you excert pressure


### PR DESCRIPTION
The regexes in the docs are out-of-date; they still use the old `xsetwacom` format. This pull request updates them to the `xinput` format.