### PR TITLE
Instruct users to install only needed dependencies

### DIFF
--- a/doc/guides/getting-started.rst
+++ b/doc/guides/getting-started.rst
@@ -29,7 +29,7 @@ On Ubuntu and its derivatives, you can install from `Martin's PPA
     $ sudo -s
     # add-apt-repository ppa:martin-ueding/stable
     # apt-get update
-    # apt-get install thinkpad-scripts
+    # apt-get install --no-install-recommends thinkpad-scripts
 
 Arch Linux
 ~~~~~~~~~~


### PR DESCRIPTION
By default, APT installs recommended packages. The problem is that `kde-baseapps-bin` is a recommended package for the `thinkpad-scripts` package, so an unwary user will install the entire KDE runtime (dependencies for `kde-baseapps-bin`) when just trying to install `thinkpad-scripts`. Using the `--no-install-recommends` option avoids this problem.