### PR TITLE
sphinx-build-3 is now located on fedora systems

### DIFF
--- a/doc/find_sphinx.py
+++ b/doc/find_sphinx.py
@@ -8,9 +8,12 @@ import os.path
 
 def main():
     ubuntu_sphinx_build = '/usr/share/sphinx/scripts/python3/sphinx-build'
+    fedora_sphinx_build = '/usr/bin/sphinx-build-3'
 
     if os.path.isfile(ubuntu_sphinx_build):
         print(ubuntu_sphinx_build)
+    elif os.path.isfile(fedora_sphinx_build):
+        print(fedora_sphinx_build)
     else:
         print('sphinx-build')
 


### PR DESCRIPTION
I noticed that the make script fails on my fedora system because it doesn't properly locate sphinx-build. This fixed it for me, so I thought it may be helpful in case other people have the same issue.