### PR TITLE
Fixed touchscreen designation for thinkpad-touch on Fedora

### DIFF
--- a/tps/default.ini
+++ b/tps/default.ini
@@ -14,7 +14,7 @@ prerotate = ~/.config/thinkpad-scripts/hooks/prerotate
 [input]
 trackpoint_device = TrackPoint
 touchpad_device = TouchPad
-touchscreen_device = Wacom ISDv4 E6 Finger touch
+touchscreen_device = Wacom ISDv4 E6 Finger
 
 [logging]
 syslog = true


### PR DESCRIPTION
On Fedora 23, the xinput name for the touchscreen device is
`Wacom ISDv4 E6 Finger`, not `Wacom ISDv4 E6 Finger touch`,
breaking the `thinkpad-touch` script. This commit fixes this by
altering the `default.ini` file accordingly.

For the sake of completeness: Here's what I got prior to this fix:

```
$ thinkpad-touch
Traceback (most recent call last):
  File "/usr/bin/thinkpad-touch", line 9, in <module>
    load_entry_point('thinkpad-scripts==4.7.3', 'console_scripts', 'thinkpad-touch')()
  File "/usr/lib/python3.4/site-packages/thinkpad_scripts-4.7.3-py3.4.egg/tps/main_touchscreen.py", line 16, in main
  File "/usr/lib/python3.4/site-packages/thinkpad_scripts-4.7.3-py3.4.egg/tps/input.py", line 183, in state_change_ui
  File "/usr/lib/python3.4/site-packages/thinkpad_scripts-4.7.3-py3.4.egg/tps/input.py", line 131, in get_xinput_id
tps.input.InputDeviceNotFoundException: Input device “Wacom ISDv4 E6 Finger touch” could not be found
```