### PR TITLE
Added optional parameter to main_rotate_hook

### DIFF
--- a/tps/hooks.py
+++ b/tps/hooks.py
@@ -96,6 +96,7 @@ def main_rotate_hook():
     parser.add_argument('ignored_two')
     parser.add_argument('ignored_three')
     parser.add_argument('key', help='Keycode')
+    parser.add_argument('ignored_k', nargs='?')
     parser.add_argument("-v", dest='verbose', action="count",
                         help='Enable verbose output. Can be supplied multiple '
                              'times for even more verbosity.')


### PR DESCRIPTION
On my Thinkpad X220 Tablet running ArchLinux rotating the display is not recognized after waking the computer from sleep mode. The reason is that acpid adds an additional parameter.  
This can be seen when running `acpi_listen`.  
Before sleep:
```
video/tabletmode TBLT 0000008A 00000001
video/tabletmode TBLT 0000008A 00000000
```
After sleep:
```
video/tabletmode TBLT 0000008A 00000001 K
video/tabletmode TBLT 0000008A 00000000 K
```
The output 
This additional `K` is not recognized by the `main_rotate_hook` which consequently fails to rotate the display.  
Adding an argument matching the `K` solves this problem.  