### PR TITLE
Add missing import of subprocess

### DIFF
--- a/tps/dock.py
+++ b/tps/dock.py
@@ -12,6 +12,7 @@ Logic related to the UltraBase® docks.
 import argparse
 import glob
 import logging
+import subprocess
 import sys
 
 import tps


### PR DESCRIPTION
The `dock(on, config)` function used `subprocess.CalledProcessError` without importing `subprocess`. This commit adds the missing import.