### PR TITLE
Detect single logged-in user as the graphical user

### DIFF
--- a/tps/hooks.py
+++ b/tps/hooks.py
@@ -76,7 +76,12 @@ def postdock(state, config):
 def get_graphicsl_user():
     pattern = re.compile(r'\(:0(\.0)?\)')
 
-    lines = tps.check_output(['who', '-u'], logger).decode().split('\n')
+    lines = tps.check_output(['who', '-u'], logger)\
+               .decode().strip().split('\n')
+    # If there is a single user, choose them.
+    if len(lines) == 1:
+        return lines[0].split()[0]
+    # Otherwise, search for a user description that matches the regex.
     for line in lines:
         m = pattern.search(line)
         if m:


### PR DESCRIPTION
The current heuristic (searching the output of `who -u` for an X display) doesn't always work. For example, on my computer, the output of `who -u` is simply:

    jim      tty1         2017-02-24 12:08 02:21         730

This commit changes `get_graphicsl_user()` so that if `who -u` lists a single logged-in user, that user is detected as the graphical user.