### PR TITLE
Add config to disable individual triggers and add ACPI hooks for docking

### DIFF
--- a/81-thinkpad-dock.rules
+++ b/81-thinkpad-dock.rules
@@ -4,7 +4,7 @@
 
 KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="0", RUN+="/usr/bin/logger -t thinkpad-dock Event caught: off"
 KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="1", RUN+="/usr/bin/logger -t thinkpad-dock Event caught: on"
-KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="0", RUN+="/usr/bin/thinkpad-dock-hook off"
-KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="1", RUN+="/usr/bin/thinkpad-dock-hook on"
+KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="0", RUN+="/usr/bin/thinkpad-dock-hook off --via-hook udev1_off"
+KERNEL=="dock.*", ATTR{type}=="dock_station", ATTR{docked}=="1", RUN+="/usr/bin/thinkpad-dock-hook on --via-hook udev1_on"
 
 # vim: ft=udevrules

--- a/doc/man/thinkpad-dock.1.rst
+++ b/doc/man/thinkpad-dock.1.rst
@@ -201,9 +201,10 @@ Those are the possible options:
 ``sound.undock_loudness``
     Volume to set to when undocking. *Default: 50%*.
 
-``trigger.enable_dock``
-    Sets whether the docking should be executed by the hardware trigger.
-    *Default: true*.
+``trigger.dock_triggers``
+    Whitespace-delimited list of the enabled hardware triggers to execute
+    docking/undocking. The available triggers are ``udev1_on`` and
+    ``udev1_off``. *Default:* ``udev1_on udev1_off``
 
 Hooks
 -----

--- a/doc/man/thinkpad-dock.1.rst
+++ b/doc/man/thinkpad-dock.1.rst
@@ -203,8 +203,9 @@ Those are the possible options:
 
 ``trigger.dock_triggers``
     Whitespace-delimited list of the enabled hardware triggers to execute
-    docking/undocking. The available triggers are ``udev1_on`` and
-    ``udev1_off``. *Default:* ``udev1_on udev1_off``
+    docking/undocking. The available triggers are ``udev1_on``, ``udev1_off``,
+    ``acpi1_on``, ``acpi1_off``, and ``acpi2``.
+    *Default:* ``udev1_on udev1_off``
 
 Hooks
 -----

--- a/doc/man/thinkpad-rotate.1.rst
+++ b/doc/man/thinkpad-rotate.1.rst
@@ -63,10 +63,6 @@ Options
     Enable verbose output. Can be supplied multiple times for even more
     verbosity.
 
-``--via-hook``
-    Let the program know that it was called using the hook. This will then
-    enable some workarounds. You do not need to care about this.
-
 ``--force-direction``
     Do not try to be smart. Actually rotate in the direction given even it
     already is the case.
@@ -167,9 +163,11 @@ You can set the following option:
     Regular expression to match the ``xrandr`` name for the internal monitor.
     *Default: LVDS-?1|eDP-?1*
 
-``trigger.enable_rotate``
-    Sets whether the rotation should be executed by the hardware trigger.
-    *Default: true*.
+``trigger.rotate_triggers``
+    Whitespace-delimited list of the enabled hardware triggers to execute
+    rotation. The available triggers are ``acpi1_normal``, ``acpi1_rotated``,
+    ``acpi2_normal``, and ``acpi2_rotated``.
+    *Default:* ``acpi1_normal acpi1_rotated acpi2_normal acpi2_rotated``
 
 ``touch.regex``
     Regular expression to match Wacom devices against. If your devices do not

--- a/makefile
+++ b/makefile
@@ -19,8 +19,10 @@ common-install:
 #
 	install -d "$(DESTDIR)/etc/acpi/events/"
 	install -m 644 thinkpad-mutemic-acpi-hook -t "$(DESTDIR)/etc/acpi/events/"
-	install -m 644 thinkpad-rotate-acpi-hook-1 -t "$(DESTDIR)/etc/acpi/events/"
-	install -m 644 thinkpad-rotate-acpi-hook-2 -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-rotate-acpi-hook-1-normal -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-rotate-acpi-hook-1-rotated -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-rotate-acpi-hook-2-normal -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-rotate-acpi-hook-2-rotated -t "$(DESTDIR)/etc/acpi/events/"
 #
 	cd desktop && $(MAKE) install
 	cd doc && $(MAKE) install

--- a/makefile
+++ b/makefile
@@ -23,6 +23,9 @@ common-install:
 	install -m 644 thinkpad-rotate-acpi-hook-1-rotated -t "$(DESTDIR)/etc/acpi/events/"
 	install -m 644 thinkpad-rotate-acpi-hook-2-normal -t "$(DESTDIR)/etc/acpi/events/"
 	install -m 644 thinkpad-rotate-acpi-hook-2-rotated -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-dock-acpi-hook-1-on -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-dock-acpi-hook-1-off -t "$(DESTDIR)/etc/acpi/events/"
+	install -m 644 thinkpad-dock-acpi-hook-2 -t "$(DESTDIR)/etc/acpi/events/"
 #
 	cd desktop && $(MAKE) install
 	cd doc && $(MAKE) install

--- a/thinkpad-dock-acpi-hook-1-off
+++ b/thinkpad-dock-acpi-hook-1-off
@@ -1,0 +1,5 @@
+# Copyright © 2017 Jim Turner <jturner314@gmail.com>
+# Licensed under The GNU Public License Version 2 (or later)
+
+event=ibm/hotkey LEN0068:00 00000080 00004011
+action=/usr/bin/thinkpad-dock-hook off --via-hook acpi1_off

--- a/thinkpad-dock-acpi-hook-1-on
+++ b/thinkpad-dock-acpi-hook-1-on
@@ -1,0 +1,5 @@
+# Copyright © 2017 Jim Turner <jturner314@gmail.com>
+# Licensed under The GNU Public License Version 2 (or later)
+
+event=ibm/hotkey LEN0068:00 00000080 00004010
+action=/usr/bin/thinkpad-dock-hook on --via-hook acpi1_on

--- a/thinkpad-dock-acpi-hook-2
+++ b/thinkpad-dock-acpi-hook-2
@@ -1,0 +1,5 @@
+# Copyright © 2017 Jim Turner <jturner314@gmail.com>
+# Licensed under The GNU Public License Version 2 (or later)
+
+event=ibm/hotkey LEN0068:00 00000080 00006030
+action=/usr/bin/thinkpad-dock-hook --via-hook acpi2

--- a/thinkpad-rotate-acpi-hook-1-normal
+++ b/thinkpad-rotate-acpi-hook-1-normal
@@ -1,0 +1,6 @@
+# Copyright © 2013 Jim Turner <jturner314@gmail.com>
+# Copyright © 2013-2014 Martin Ueding <dev@martin-ueding.de>
+# Licensed under The GNU Public License Version 2 (or later)
+
+event=ibm/hotkey HKEY 00000080 0000500a
+action=/usr/bin/thinkpad-rotate-hook normal --via-hook acpi1_normal

--- a/thinkpad-rotate-acpi-hook-1-rotated
+++ b/thinkpad-rotate-acpi-hook-1-rotated
@@ -2,5 +2,5 @@
 # Copyright © 2013-2014 Martin Ueding <dev@martin-ueding.de>
 # Licensed under The GNU Public License Version 2 (or later)
 
-event=ibm/hotkey HKEY 00000080 0000500[9a]
-action=/usr/bin/thinkpad-rotate-hook %e
+event=ibm/hotkey HKEY 00000080 00005009
+action=/usr/bin/thinkpad-rotate-hook --via-hook acpi1_rotated

--- a/thinkpad-rotate-acpi-hook-2-normal
+++ b/thinkpad-rotate-acpi-hook-2-normal
@@ -1,0 +1,6 @@
+# Copyright © 2013 Jim Turner <jturner314@gmail.com>
+# Copyright © 2013-2014 Martin Ueding <dev@martin-ueding.de>
+# Licensed under The GNU Public License Version 2 (or later)
+
+event=video/tabletmode TBLT 0000008A 00000000.*
+action=/usr/bin/thinkpad-rotate-hook normal --via-hook acpi2_normal

--- a/thinkpad-rotate-acpi-hook-2-rotated
+++ b/thinkpad-rotate-acpi-hook-2-rotated
@@ -2,5 +2,5 @@
 # Copyright © 2013-2014 Martin Ueding <dev@martin-ueding.de>
 # Licensed under The GNU Public License Version 2 (or later)
 
-event=video/tabletmode TBLT 0000008A 0000000[01].*
-action=/usr/bin/thinkpad-rotate-hook %e
+event=video/tabletmode TBLT 0000008A 00000001.*
+action=/usr/bin/thinkpad-rotate-hook --via-hook acpi2_rotated

--- a/tps/default.ini
+++ b/tps/default.ini
@@ -47,8 +47,8 @@ undock_loudness = 50%
 unmute = true
 
 [trigger]
-enable_dock = true
-enable_rotate = true
+dock_triggers = udev1_on udev1_off
+rotate_triggers = acpi1_normal acpi1_rotated acpi2_normal acpi2_rotated
 
 [touch]
 regex = Wacom ISD.*id=(\d+)

--- a/tps/hooks.py
+++ b/tps/hooks.py
@@ -97,39 +97,32 @@ def main_rotate_hook():
     interpreter with the actual ``thinkpad-rotate`` script.
     '''
     parser = argparse.ArgumentParser()
-    parser.add_argument('ignored_one')
-    parser.add_argument('ignored_two')
-    parser.add_argument('ignored_three')
-    parser.add_argument('key', help='Keycode')
-    parser.add_argument('ignored_k', nargs='?')
+    parser.add_argument('direction', nargs='?', help='Direction to rotate to.')
+    parser.add_argument('--via-hook', required=True,
+                        help='ID of hook that called this program')
     parser.add_argument("-v", dest='verbose', action="count",
                         help='Enable verbose output. Can be supplied multiple '
                              'times for even more verbosity.')
     options = parser.parse_args()
     tps.config.set_up_logging(options.verbose)
 
-    key = options.key
-
-    if key in ('00000001', '00005009'):
-        set_to = ''
-
-    elif key in ('00000000', '0000500a'):
-        set_to = 'normal'
-
+    if options.direction is not None:
+        direction = [options.direction, '--force-direction']
     else:
-        logger.error('Unexpected keycode %s given in rotate-hook', key)
-        sys.exit(1)
+        direction = []
 
     user = get_graphicsl_user()
     if user is None:
         logger.warning('Unable to get graphical user. Ignoring trigger.')
         sys.exit(0)
 
-    tps.check_call([
-        'sudo', '-u', user, '-i',
-        'env', 'DISPLAY=:0.0',
-        '/usr/bin/thinkpad-rotate', set_to, '--via-hook',
-    ], logger)
+    tps.check_call(
+        ['sudo', '-u', user, '-i',
+         'env', 'DISPLAY=:0.0',
+         '/usr/bin/thinkpad-rotate'] +
+        direction +
+        ['--via-hook', options.via_hook],
+        logger)
 
 
 def main_dock_hook():
@@ -140,20 +133,30 @@ def main_dock_hook():
     interpreter with the actual ``thinkpad-dock`` script.
     '''
     parser = argparse.ArgumentParser()
-    parser.add_argument('action', help='`on` or `off`')
+    parser.add_argument('action', nargs='?', choices=['on', 'off'],
+                        help='`on` or `off`')
+    parser.add_argument('--via-hook', required=True,
+                        help='ID of hook that called this program')
     parser.add_argument("-v", dest='verbose', action="count",
                         help='Enable verbose output. Can be supplied multiple '
                              'times for even more verbosity.')
     options = parser.parse_args()
     tps.config.set_up_logging(options.verbose)
 
+    if options.action is not None:
+        action = [options.action]
+    else:
+        action = []
+
     user = get_graphicsl_user()
     if user is None:
         logger.warning('Unable to get graphical user. Ignoring trigger.')
         sys.exit(0)
 
-    tps.check_call([
-        'sudo', '-u', user, '-i',
-        'env', 'DISPLAY=:0.0',
-        '/usr/bin/thinkpad-dock', options.action, '--via-hook'
-    ], logger)
+    tps.check_call(
+        ['sudo', '-u', user, '-i',
+         'env', 'DISPLAY=:0.0',
+         '/usr/bin/thinkpad-dock'] +
+        action +
+        ['--via-hook', options.via_hook],
+        logger)

--- a/tps/rotate.py
+++ b/tps/rotate.py
@@ -29,10 +29,19 @@ def main():
 
     # Quickly abort if the call is by the hook and the user disabled the
     # trigger.
-    if options.via_hook and not config['trigger'].getboolean('enable_rotate'):
-        sys.exit(0)
+    if options.via_hook is not None:
+        if 'enable_rotate' in config['trigger']:
+            # The user has this key in his configuration. The default does not
+            # have it anymore, so this must be manual.
+            if config['trigger'].getboolean('enable_rotate'):
+                logger.warning('You have specified the deprecated trigger.enable_rotate option in your configuration file. The new config option is trigger.rotate_triggers, which is a list of enabled triggers. This program will use your existing trigger.enable_rotate value, but please update your config. To update your config while keeping the behavior of your current config, simply remove trigger.enable_rotate from your config file.')
+            else:
+                logger.warning('You have specified the deprecated trigger.enable_rotate option in your configuration file. The new config option is trigger.rotate_triggers, which is a list of enabled triggers. This program will use your existing trigger.enable_rotate value, but please update your config. To update your config while keeping the behavior of your current config, remove trigger.enable_rotate from your config file and set trigger.rotate_triggers to an empty value.')
+                sys.exit(0)
+        elif options.via_hook not in config['trigger']['rotate_triggers'].split():
+            sys.exit(0)
 
-    if options.via_hook:
+    if options.via_hook is not None:
         xrandr_bug_fail_early(config)
 
     try:
@@ -220,7 +229,7 @@ def _parse_args():
     parser.add_argument("-v", dest='verbose', action="count",
                         help='Enable verbose output. Can be supplied multiple '
                              'times for even more verbosity.')
-    parser.add_argument('--via-hook', action='store_true', help='Let the program know that it was called using the hook. This will then enable some workarounds. You do not need to care about this.')
+    parser.add_argument('--via-hook', help='Let the program know that it was called using the specified hook. You do not need to care about this.')
     parser.add_argument('--force-direction', action='store_true', help='Do not try to be smart. Actually rotate in the direction given even it already is the case.')
 
     options = parser.parse_args()


### PR DESCRIPTION
This PR does the following:

1. Replace the `trigger.enable_dock` and `trigger.enable_rotate` config options with `trigger.dock_triggers` and `trigger.rotate_triggers`, which each take a list of enabled triggers. This makes it possible to enable/disable individual hardware triggers. (This is necessary to prevent calling scripts twice if there are multiple triggers for a single event, such as the udev rule and ACPI hooks for docking.)

2. Remove mention of `--via-hook` from the `thinkpad-rotate` man page to further discourage users from using it.

3. Add ACPI hooks for docking, based on #130 and testing on my laptop.

I've made an effort to maintain user-facing backwards compatibility. These changes allow users to upgrade without changing their config while maintaining the current behavior. The only possible backwards incompatibilities are:

1. If users are calling `thinkpad-rotate-hook` or `thinkpad-dock-hook` themselves, the command line arguments have changed. I think this is okay because `thinkpad-rotate-hook` and `thinkpad-dock-hook` are undocumented.

2. If users are using the `--via-hook` argument themselves, it now requires a value. (It's no longer `store_true`.) I think this is okay because the help and docs tell users to ignore the `--via-hook` option, but if you think this is an issue, we can add a new command line argument instead.

This PR fixes #130 with the config option `trigger.dock_triggers` set to `acpi1_on acpi1_off`.