### PR TITLE
Make graphical user detection handle (:1) display

### DIFF
--- a/tps/hooks.py
+++ b/tps/hooks.py
@@ -74,19 +74,26 @@ def postdock(state, config):
 
 
 def get_graphicsl_user():
-    pattern = re.compile(r'\(:0(\.0)?\)')
-
     lines = tps.check_output(['who', '-u'], logger)\
                .decode().strip().split('\n')
+    return parse_graphical_user(lines)
+
+
+def parse_graphical_user(lines):
+    '''Determine the graphical user from the output of ``who -u``.'''
     # If there is a single user, choose them.
     if len(lines) == 1:
         return lines[0].split()[0]
     # Otherwise, search for a user description that matches the regex.
+    # 'z' is always greater than any match by the regular expression.
+    display = 'z'
+    user = None
     for line in lines:
-        m = pattern.search(line)
-        if m:
-            words = line.split()
-            return words[0]
+        m = re.search(r'\(:\d+(\.\d+)?\)', line)
+        if m and m.group(0) < display:
+            display = m.group(0)
+            user = line.split()[0]
+    return user
 
 
 def main_rotate_hook():

--- a/tps/testsuite/test_hooks.py
+++ b/tps/testsuite/test_hooks.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# Copyright © 2017 Jim Turner <jturner314@gmail.com>
+# Licensed under The GNU Public License Version 2 (or later)
+
+import unittest
+
+import tps.input
+
+class ParseGraphicalUserTestCase(unittest.TestCase):
+
+    def test_parse_graphical_user_single(self):
+        lines = [
+            'foo      tty1         2017-03-14 16:14 21:11         683',
+        ]
+        user = tps.hooks.parse_graphical_user(lines)
+        self.assertEqual(user, 'foo')
+
+    def test_parse_graphical_user_display_zero(self):
+        lines = [
+            'bar     tty1         2017-03-14 12:02 23:25        683',
+            'foo     tty1         2017-03-14 12:02 23:25        683 (:0)',
+            'baz     tty1         2017-03-14 12:02 23:25        683',
+        ]
+        user = tps.hooks.parse_graphical_user(lines)
+        self.assertEqual(user, 'foo')
+
+    def test_parse_graphical_user_display_zero_point_zero(self):
+        lines = [
+            'bar     tty1         2017-03-14 12:02 23:25        683',
+            'foo     tty1         2017-03-14 12:02 23:25        683 (:0.0)',
+            'baz     tty1         2017-03-14 12:02 23:25        683',
+        ]
+        user = tps.hooks.parse_graphical_user(lines)
+        self.assertEqual(user, 'foo')
+
+    def test_parse_graphical_user_display_one(self):
+        lines = [
+            'bar     tty1         2017-03-14 12:02 23:25        683',
+            'foo     tty1         2017-03-14 12:02 23:25        683 (:1)',
+            'baz     tty1         2017-03-14 12:02 23:25        683',
+        ]
+        user = tps.hooks.parse_graphical_user(lines)
+        self.assertEqual(user, 'foo')
+
+    def test_parse_graphical_user_display_zero_with_one(self):
+        lines = [
+            'bar     tty1         2017-03-14 12:02 23:25        683 (:1)',
+            'foo     tty1         2017-03-14 12:02 23:25        683 (:0)',
+            'baz     tty1         2017-03-14 12:02 23:25        683',
+        ]
+        user = tps.hooks.parse_graphical_user(lines)
+        self.assertEqual(user, 'foo')


### PR DESCRIPTION
The only display listed in `who -u` may be `(:1)` instead of `(:0)` (see issue #136), so this commit adds support for that case. Additionally, this commit breaks `get_graphicsl_user()` into two functions and adds testing for the parsing function.