### PR TITLE
Add conditional for local logging (#145)

### DIFF
--- a/tps/config.py
+++ b/tps/config.py
@@ -211,6 +211,8 @@ def set_up_logging(verbosity):
         dev_log = '/dev/log'
         if os.path.exists(dev_log):
             kwargs['address'] = dev_log
+        else:
+            kwargs['address'] = 'localhost'
         syslog = logging.handlers.SysLogHandler(**kwargs)
         syslog.setLevel(logging.DEBUG)
         formatter = logging.Formatter(syslog_format)


### PR DESCRIPTION
## Issue
This pull request aims to resolve issue [#145](https://github.com/martin-ueding/thinkpad-scripts/issues/145).
## Description
If `/dev/log` doesn't exist on the system (for instance, if the user doesn't have a syslogger set up), then instead of setting the syslog address and port to `('localhost', 514)` (by default) according to the [docs](https://docs.python.org/3/library/logging.handlers.html#sysloghandler), set _only_ the address to `'localhost'`.

This prevents the name resolution failure that occurs when running `thinkpad-rotate` without an Internet connection as described in [#145](https://github.com/martin-ueding/thinkpad-scripts/issues/145).

## Appendix
Perhaps in the case of not having a syslogger and the `localhost` case is reached, `thinkpad-scripts` could log to the kernel. This may or may not be desired behavior, but some scripts interface with hardware (e.g. rotating the _screen_, docking (_udev_)) and therefore would interface with the kernel. In this case, though, perhaps it would be desired rather to log to the kernel by default.

I have not included any of these suggestions in this pull request, only the changes mentioned in [_Description_](#description).